### PR TITLE
Allow reprocessing existing eval output csvs & Streamline progress UI

### DIFF
--- a/evaluate_model.py
+++ b/evaluate_model.py
@@ -2,11 +2,13 @@
 
 import argparse
 import concurrent.futures
+
 import datasets
 import jiwer
 import pandas
-from hebrew import Hebrew
 import whisper.normalizers
+from hebrew import Hebrew
+from tqdm import tqdm
 
 
 def clean_some_unicode_from_text(text):
@@ -65,11 +67,14 @@ def process_entry(args):
         if key not in ["audio", text_column]:
             entry_data[f"metadata_{key}"] = entry[key]
 
-    print(
-        f"Evaluated entry {i+1}, WER={entry_metrics.wer}, WIL={entry_metrics.wil}, ref_text={ref_text}, eval_text={eval_text}"
-    )
     return entry_data
 
+def calculate_final_metrics(entries_data: list[dict]):
+    # Calculate final metrics
+    return jiwer.process_words(
+        [entry["norm_reference_text"] for entry in entries_data],
+        [entry["norm_predicted_text"] for entry in entries_data],
+    )
 
 def evaluate_model(transcribe_fn, ds, text_column, num_workers=1):
     normalizer = HebrewTextNormalizer()
@@ -78,22 +83,44 @@ def evaluate_model(transcribe_fn, ds, text_column, num_workers=1):
     # Prepare arguments for parallel processing
     process_args = [(i, ds[i], transcribe_fn, text_column, normalizer) for i in range(len(ds))]
 
-    # Process entries in parallel
+    # Process entries in parallel with progress tracking
     with concurrent.futures.ThreadPoolExecutor(max_workers=num_workers) as executor:
+        # Submit tasks
+        futures = [executor.submit(process_entry, arg) for arg in process_args]
+
+        # Use tqdm to track progress
+        entries_data = []
+        with tqdm(total=len(futures), desc="Processing entries") as pbar:
+            for future in concurrent.futures.as_completed(futures):
+                entry = future.result()
+                entries_data.append(entry)
+                last_wer = entry["wer"]
+                last_wil = entry["wil"]
+                pbar.set_postfix(last_wer=f"{last_wer:.5f}", last_wil=f"{last_wil:.5f}")
+                pbar.update(1)
+        
         entries_data = list(executor.map(process_entry, process_args))
 
     # Sort results by ID to maintain original order
     entries_data.sort(key=lambda x: x["id"])
 
     # Calculate final metrics
-    final_metrics = jiwer.process_words(
-        [entry["norm_reference_text"] for entry in entries_data],
-        [entry["norm_predicted_text"] for entry in entries_data],
-    )
+    final_metrics = calculate_final_metrics(entries_data)
 
     results_df = pandas.DataFrame(entries_data)
     return final_metrics, results_df
 
+def reevaluate_model_results_file(results_csv_file: str):
+    # get df from csv file
+    df = pandas.read_csv(results_csv_file)
+
+    # srt by id column
+    df = df.sort_values(by=["id"])
+
+    # convert to list of dicts
+    entries_data = df.to_dict(orient="records")
+
+    return calculate_final_metrics(entries_data)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Evaluate a speech-to-text model.")
@@ -105,40 +132,46 @@ if __name__ == "__main__":
     parser.add_argument("--name", type=str, required=False, help="Optional name parameter for dataset.load_dataset")
     parser.add_argument("--output", type=str, default="evaluation_results.csv", help="Output CSV file path")
     parser.add_argument("--workers", type=int, default=1, help="Number of parallel workers to use for evaluation")
+    parser.add_argument(
+        "--reevaluate_existing", action="store_true", help="Reevaluate existing results file instead of evaluating"
+    )
 
     args = parser.parse_args()
 
-    # Import the engine module
-    import importlib.util
-
-    spec = importlib.util.spec_from_file_location("engine", args.engine)
-    engine = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(engine)
-
-    print(f"Loading engine {args.engine} with model {args.model}...")
-    transcribe_fn = engine.create_app(model_path=args.model)
-
-    print(f"Loading dataset {args.dataset}...")
-    dataset_parts = args.dataset.split(":")
-    dataset_name = dataset_parts[0]
-    dataset_split = dataset_parts[1] if len(dataset_parts) > 1 else "test"
-    ds_text_column = dataset_parts[2] if len(dataset_parts) > 2 else "text"
-
-    if args.name:
-        ds = datasets.load_dataset(dataset_name, name=args.name, trust_remote_code=True)[dataset_split]
+    if args.reevaluate_existing:
+        metrics = reevaluate_model_results_file(args.output)
     else:
-        ds = datasets.load_dataset(dataset_name, trust_remote_code=True)[dataset_split]
+        # Import the engine module
+        import importlib.util
 
-    print(f"Beginning evaluation with {args.workers} workers.")
-    metrics, results_df = evaluate_model(transcribe_fn, ds, ds_text_column, args.workers)
+        spec = importlib.util.spec_from_file_location("engine", args.engine)
+        engine = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(engine)
 
+        print(f"Loading engine {args.engine} with model {args.model}...")
+        transcribe_fn = engine.create_app(model_path=args.model)
+
+        print(f"Loading dataset {args.dataset}...")
+        dataset_parts = args.dataset.split(":")
+        dataset_name = dataset_parts[0]
+        dataset_split = dataset_parts[1] if len(dataset_parts) > 1 else "test"
+        ds_text_column = dataset_parts[2] if len(dataset_parts) > 2 else "text"
+
+        if args.name:
+            ds = datasets.load_dataset(dataset_name, name=args.name, trust_remote_code=True)[dataset_split]
+        else:
+            ds = datasets.load_dataset(dataset_name, trust_remote_code=True)[dataset_split]
+
+        print(f"Beginning evaluation with {args.workers} workers.")
+        metrics, results_df = evaluate_model(transcribe_fn, ds, ds_text_column, args.workers)
+
+        # Add model and dataset info as columns
+        results_df["model"] = args.model
+        results_df["dataset"] = dataset_name
+        results_df["dataset_split"] = dataset_split
+        results_df["engine"] = args.engine
+
+        results_df.to_csv(args.output, encoding="utf-8", index=False)
+        print(f"Results saved to {args.output}")
+    
     print(f"Evaluation done. WER={metrics.wer}, WIL={metrics.wil}.")
-
-    # Add model and dataset info as columns
-    results_df["model"] = args.model
-    results_df["dataset"] = dataset_name
-    results_df["dataset_split"] = dataset_split
-    results_df["engine"] = args.engine
-
-    results_df.to_csv(args.output, encoding="utf-8", index=False)
-    print(f"Results saved to {args.output}")

--- a/evaluate_model.py
+++ b/evaluate_model.py
@@ -2,6 +2,7 @@
 
 import argparse
 import concurrent.futures
+import os
 
 import datasets
 import jiwer
@@ -135,13 +136,13 @@ if __name__ == "__main__":
     parser.add_argument("--name", type=str, required=False, help="Optional name parameter for dataset.load_dataset")
     parser.add_argument("--output", type=str, default="evaluation_results.csv", help="Output CSV file path")
     parser.add_argument("--workers", type=int, default=1, help="Number of parallel workers to use for evaluation")
-    parser.add_argument(
-        "--reevaluate_existing", action="store_true", help="Reevaluate existing results file instead of evaluating"
-    )
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite exists outputs, otherwise - reuse them")
 
     args = parser.parse_args()
 
-    if args.reevaluate_existing:
+    output_exists = os.path.exists(args.output)
+
+    if output_exists and not args.overwrite:
         metrics = reevaluate_model_results_file(args.output)
     else:
         # Import the engine module

--- a/evaluate_model.py
+++ b/evaluate_model.py
@@ -69,12 +69,15 @@ def process_entry(args):
 
     return entry_data
 
+
 def calculate_final_metrics(entries_data: list[dict]):
     # Calculate final metrics
-    return jiwer.process_words(
+    results = jiwer.process_words(
         [entry["norm_reference_text"] for entry in entries_data],
         [entry["norm_predicted_text"] for entry in entries_data],
     )
+    return results
+
 
 def evaluate_model(transcribe_fn, ds, text_column, num_workers=1):
     normalizer = HebrewTextNormalizer()
@@ -98,8 +101,6 @@ def evaluate_model(transcribe_fn, ds, text_column, num_workers=1):
                 last_wil = entry["wil"]
                 pbar.set_postfix(last_wer=f"{last_wer:.5f}", last_wil=f"{last_wil:.5f}")
                 pbar.update(1)
-        
-        entries_data = list(executor.map(process_entry, process_args))
 
     # Sort results by ID to maintain original order
     entries_data.sort(key=lambda x: x["id"])
@@ -109,6 +110,7 @@ def evaluate_model(transcribe_fn, ds, text_column, num_workers=1):
 
     results_df = pandas.DataFrame(entries_data)
     return final_metrics, results_df
+
 
 def reevaluate_model_results_file(results_csv_file: str):
     # get df from csv file
@@ -121,6 +123,7 @@ def reevaluate_model_results_file(results_csv_file: str):
     entries_data = df.to_dict(orient="records")
 
     return calculate_final_metrics(entries_data)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Evaluate a speech-to-text model.")
@@ -173,5 +176,5 @@ if __name__ == "__main__":
 
         results_df.to_csv(args.output, encoding="utf-8", index=False)
         print(f"Results saved to {args.output}")
-    
+
     print(f"Evaluation done. WER={metrics.wer}, WIL={metrics.wil}.")

--- a/run_bench.py
+++ b/run_bench.py
@@ -50,11 +50,11 @@ def main():
             "--workers",
             str(args.workers),
             "--output",
-            output_file,
-            "--overwrite",
-            args.overwrite
+            output_file
         ]
 
+        if args.overwrite:
+            cmd.append("--overwrite")
         if ds_name:
             cmd.extend(["--name", ds_name])
 

--- a/run_bench.py
+++ b/run_bench.py
@@ -13,7 +13,7 @@ def main():
     parser.add_argument("--model", required=True, help="Model to use")
     parser.add_argument("--output-dir", required=True, help="Directory to store evaluation results")
     parser.add_argument("--workers", type=int, default=8, help="Number of parallel workers")
-    parser.add_argument("--overwrite", action="store_true", help="Overwrite existing output files")
+    parser.add_argument("--overwrite", action="store_true", help="Overwrite existing output files if exists")
     args = parser.parse_args()
 
     # Ensure engine script exists
@@ -37,12 +37,6 @@ def main():
     for ds_path, ds_name, ds_output_name in datasets:
         output_file = os.path.join(args.output_dir, f"{ds_output_name}.csv")
 
-        reevaluate_existing = False
-        if os.path.exists(output_file):
-            if not args.overwrite:
-                reevaluate_existing = True
-                print(f"Reevaluating exiting results in {ds_path}.")
-
         print(f"Evaluating {ds_path}...")
 
         cmd = [
@@ -57,10 +51,10 @@ def main():
             str(args.workers),
             "--output",
             output_file,
+            "--overwrite",
+            args.overwrite
         ]
 
-        if reevaluate_existing:
-            cmd.append("--reevaluate_existing")
         if ds_name:
             cmd.extend(["--name", ds_name])
 

--- a/run_bench.py
+++ b/run_bench.py
@@ -37,9 +37,11 @@ def main():
     for ds_path, ds_name, ds_output_name in datasets:
         output_file = os.path.join(args.output_dir, f"{ds_output_name}.csv")
 
-        if os.path.exists(output_file) and not args.overwrite:
-            print(f"Skipping {ds_path} - output file {output_file} already exists")
-            continue
+        reevaluate_existing = False
+        if os.path.exists(output_file):
+            if not args.overwrite:
+                reevaluate_existing = True
+                print(f"Reevaluating exiting results in {ds_path}.")
 
         print(f"Evaluating {ds_path}...")
 
@@ -57,6 +59,8 @@ def main():
             output_file,
         ]
 
+        if reevaluate_existing:
+            cmd.append("--reevaluate_existing")
         if ds_name:
             cmd.extend(["--name", ds_name])
 


### PR DESCRIPTION
- Existing CSV's are reloaded and metrics are calculated from them (if not --overwrite)
- More fluent progress UX - Dont print out text, show tqdm progress bars and last per-sample wer/wil
- Track progress across all datasets and samples within